### PR TITLE
dont run dev subscription listener on console

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,25 +8,25 @@
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.11.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "5.0.0"
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
             },
             "type": "library",
             "autoload": {
@@ -46,12 +46,17 @@
                 "arithmetic",
                 "bigdecimal",
                 "bignum",
+                "bignumber",
                 "brick",
-                "math"
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.11.0"
+                "source": "https://github.com/brick/math/tree/0.12.1"
             },
             "funding": [
                 {
@@ -59,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-15T23:15:59+00:00"
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -1012,20 +1017,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.5",
+            "version": "4.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e"
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
-                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -1088,7 +1093,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.5"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
             },
             "funding": [
                 {
@@ -1100,7 +1105,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-08T05:53:05+00:00"
+            "time": "2024-04-27T21:32:50+00:00"
         },
         {
             "name": "symfony/cache",
@@ -6078,12 +6083,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "74d263d0c5bb600a8c7254f031c81de7c6267e59"
+                "reference": "c9920ef42818bc65373cec1acc26bdee7a487e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/74d263d0c5bb600a8c7254f031c81de7c6267e59",
-                "reference": "74d263d0c5bb600a8c7254f031c81de7c6267e59",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c9920ef42818bc65373cec1acc26bdee7a487e72",
+                "reference": "c9920ef42818bc65373cec1acc26bdee7a487e72",
                 "shasum": ""
             },
             "conflict": {
@@ -6491,7 +6496,7 @@
                 "pagarme/pagarme-php": "<3",
                 "pagekit/pagekit": "<=1.0.18",
                 "paragonie/random_compat": "<2",
-                "passbolt/passbolt_api": "<2.11",
+                "passbolt/passbolt_api": "<4.6.2",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -6860,7 +6865,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-26T00:14:37+00:00"
+            "time": "2024-04-26T17:04:41+00:00"
         },
         {
             "name": "sanmai/later",

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -195,6 +195,10 @@ patchlevel_event_sourcing:
     subscription:
         auto_setup: true
 ```
+!!! note
+
+    This works only before each http requests and not if you use the console commands.
+    
 ### Rebuild After File Change
 
 If you want to rebuild the subscription engine after a file change, you can activate this option.
@@ -205,6 +209,10 @@ patchlevel_event_sourcing:
     subscription:
         rebuild_after_file_change: true
 ```
+!!! note
+
+    This works only before each http requests and not if you use the console commands.
+    
 ## Event Bus
 
 You can enable the event bus to listen for events and messages synchronously.

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -371,11 +371,6 @@ final class PatchlevelEventSourcingExtension extends Extension
                     'event' => 'kernel.request',
                     'priority' => 200,
                     'method' => 'onKernelRequest',
-                ])
-                ->addTag('kernel.event_listener', [
-                    'priority' => 200,
-                    'event' => 'console.command',
-                    'method' => 'onConsoleCommand',
                 ]);
         }
 
@@ -394,11 +389,6 @@ final class PatchlevelEventSourcingExtension extends Extension
                 'event' => 'kernel.request',
                 'priority' => 100,
                 'method' => 'onKernelRequest',
-            ])
-            ->addTag('kernel.event_listener', [
-                'priority' => 100,
-                'event' => 'console.command',
-                'method' => 'onConsoleCommand',
             ]);
     }
 

--- a/src/RequestListener/AutoSetupListener.php
+++ b/src/RequestListener/AutoSetupListener.php
@@ -7,7 +7,6 @@ namespace Patchlevel\EventSourcingBundle\RequestListener;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
 use Patchlevel\EventSourcing\Subscription\Status;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 final class AutoSetupListener
@@ -29,16 +28,6 @@ final class AutoSetupListener
             return;
         }
 
-        $this->run();
-    }
-
-    public function onConsoleCommand(ConsoleCommandEvent $event): void
-    {
-        $this->run();
-    }
-
-    private function run(): void
-    {
         $subscriptions = $this->subscriptionEngine->subscriptions(
             new SubscriptionEngineCriteria(
                 $this->ids,

--- a/src/RequestListener/SubscriptionRebuildAfterFileChangeListener.php
+++ b/src/RequestListener/SubscriptionRebuildAfterFileChangeListener.php
@@ -11,7 +11,6 @@ use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 use function filemtime;
@@ -33,16 +32,6 @@ final class SubscriptionRebuildAfterFileChangeListener
             return;
         }
 
-        $this->run();
-    }
-
-    public function onConsoleCommand(ConsoleCommandEvent $event): void
-    {
-        $this->run();
-    }
-
-    private function run(): void
-    {
         $toRemove = [];
         $itemsToSave = [];
 


### PR DESCRIPTION
These listeners do not work well with console commands. Every command would attempt to execute `auto_setup` and `rebuild_on_change` and thus query the database. This doesn't work if you don't have a database yet and want to create it with the console. Also it would be executed if you performed database independent actions like `cache:clear` and `assets:install`, which definitely shouldn't happen.

That's why the two dev listeners no longer listen to console commands and only listen to http requests.

People are already considering whether there is a better alternative. Such as a `watch` command that can be run in parallel, which then replaces these two options `auto_setup` and `rebuild_on_change`.