### PR TITLE
Enable injection by arregate repo name

### DIFF
--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -328,7 +328,6 @@ use App\Hotel\Domain\Hotel;
 use App\Hotel\Infrastructure\Projection\HotelProjection;
 use Patchlevel\EventSourcing\Aggregate\Uuid;
 use Patchlevel\EventSourcing\Repository\Repository;
-use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -341,10 +340,8 @@ final class HotelController
     private Repository $hotelRepository;
 
     public function __construct(
-        RepositoryManager $repositoryManager,
         private HotelProjection $hotelProjection,
     ) {
-        $this->hotelRepository = $repositoryManager->get(Hotel::class);
     }
 
     #[Route('/', methods:['GET'])]

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -336,11 +336,10 @@ use Symfony\Component\Routing\Annotation\Route;
 #[AsController]
 final class HotelController
 {
-    /** @var Repository<Hotel> */
-    private Repository $hotelRepository;
-
     public function __construct(
-        private HotelProjection $hotelProjection,
+        private readonly HotelProjection $hotelProjection,
+        /** @var Repository<Hotel> */
+        private readonly Repository $hotelRepository,
     ) {
     }
 

--- a/docs/pages/usage.md
+++ b/docs/pages/usage.md
@@ -11,13 +11,14 @@ But we provide only examples for specific symfo
     
 ## Repository
 
-You can access the specific repositories using the `RepositoryManager`.
+You can access the specific repositories using the `RepositoryManager::get`. Or inject directly the right repository via 
+argument name injection. For our aggregate `Hotel` it would be `$hotelRepository`.
 
 ```php
 namespace App\Hotel\Infrastructure\Controller;
 
 use Patchlevel\EventSourcing\Aggregate\Uuid;
-use Patchlevel\EventSourcing\Repository\RepositoryManager;
+use Patchlevel\EventSourcing\Repository\Repository;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 
@@ -25,14 +26,14 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 final class HotelController
 {
     public function __construct(
-        private readonly RepositoryManager $repositoryManager,
+        /** @var Repository<Hotel> */
+        private readonly Repository $hotelRepository,
     ) {
     }
 
     public function doStuffAction(Uuid $hotelId): Response
     {
-        $hotelRepository = $this->repositoryManager->get(Hotel::class);
-        $hotel = $hotelRepository->load($hotelId);
+        $hotel = $this->hotelRepository->load($hotelId);
 
         $hotel->doStuff();
 

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -69,7 +69,6 @@ use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
-use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
 use Patchlevel\EventSourcing\Schema\DoctrineMigrationSchemaProvider;
@@ -127,7 +126,6 @@ use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -544,21 +542,6 @@ final class PatchlevelEventSourcingExtension extends Extension
             ->addTag('monolog.logger', ['channel' => 'event_sourcing']);
 
         $container->setAlias(RepositoryManager::class, DefaultRepositoryManager::class);
-
-        $aggregateRootRegistry = (new AttributeAggregateRootRegistryFactory())->create($config['aggregates']);
-
-        foreach ($aggregateRootRegistry->aggregateNames() as $aggregateName) {
-            $aggregateRepositoryName = $aggregateName . 'Repository';
-            $aggregateRepositoryId = 'eventsourcing.' . $aggregateName . '.repository';
-
-            $definition = new Definition(Repository::class);
-            $definition->setPublic(false);
-            $definition->setFactory([new Reference(RepositoryManager::class), 'get']);
-            $definition->setArgument(0, $aggregateRootRegistry->aggregateClass($aggregateName));
-
-            $container->setDefinition($aggregateRepositoryId, $definition);
-            $container->registerAliasForArgument($aggregateRepositoryId, Repository::class, $aggregateRepositoryName)->setPublic(false);
-        }
     }
 
     private function configureCommands(ContainerBuilder $container): void

--- a/src/DependencyInjection/RepositoryCompilerPass.php
+++ b/src/DependencyInjection/RepositoryCompilerPass.php
@@ -9,6 +9,7 @@ use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -17,7 +18,7 @@ final class RepositoryCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $aggregateRootRegistry = $container->get(AggregateRootRegistry::class);
+        $aggregateRootRegistry = $container->get(AggregateRootRegistry::class, ContainerInterface::NULL_ON_INVALID_REFERENCE);
 
         if (!$aggregateRootRegistry instanceof AggregateRootRegistry) {
             return;

--- a/src/DependencyInjection/RepositoryCompilerPass.php
+++ b/src/DependencyInjection/RepositoryCompilerPass.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\DependencyInjection;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\RepositoryManager;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/** @interal */
+final class RepositoryCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $aggregateRootRegistry = $container->get(AggregateRootRegistry::class);
+
+        if (!$aggregateRootRegistry instanceof AggregateRootRegistry) {
+            return;
+        }
+
+        foreach ($aggregateRootRegistry->aggregateNames() as $aggregateName) {
+            $aggregateRepositoryName = $aggregateName . 'Repository';
+            $aggregateRepositoryId = 'event_sourcing.' . $aggregateName . '.repository';
+
+            $definition = new Definition(Repository::class);
+            $definition->setPublic(false);
+            $definition->setFactory([new Reference(RepositoryManager::class), 'get']);
+            $definition->setArgument(0, $aggregateRootRegistry->aggregateClass($aggregateName));
+
+            $container->setDefinition($aggregateRepositoryId, $definition);
+            $container->registerAliasForArgument($aggregateRepositoryId, Repository::class, $aggregateRepositoryName)->setPublic(false);
+        }
+    }
+}

--- a/src/PatchlevelEventSourcingBundle.php
+++ b/src/PatchlevelEventSourcingBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcingBundle;
 
+use Patchlevel\EventSourcingBundle\DependencyInjection\RepositoryCompilerPass;
 use Patchlevel\EventSourcingBundle\DependencyInjection\TraceCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -13,5 +14,6 @@ final class PatchlevelEventSourcingBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new TraceCompilerPass());
+        $container->addCompilerPass(new RepositoryCompilerPass());
     }
 }

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -39,6 +39,7 @@ use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
+use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaProvider;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaSubscriber;
@@ -835,6 +836,30 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertInstanceOf(AggregateRootRegistry::class, $container->get(AggregateRootRegistry::class));
         self::assertInstanceOf(RepositoryManager::class, $container->get(RepositoryManager::class));
         self::assertInstanceOf(EventRegistry::class, $container->get(EventRegistry::class));
+    }
+    public function testNamedRepository(): void
+    {
+        $container = new ContainerBuilder();
+
+        $this->compileContainer(
+            $container,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'service' => 'doctrine.dbal.eventstore_connection',
+                    ],
+                    'aggregates' => [__DIR__ . '/../Fixtures'],
+                ],
+            ]
+        );
+
+        $profileRepository = $container->get('event_sourcing.profile.repository');
+        self::assertInstanceOf(Repository::class, $profileRepository);
+
+        $namedArgumentProfileRepository = $container->get(Repository::class . ' $profileRepository');
+        self::assertInstanceOf(Repository::class, $namedArgumentProfileRepository);
+
+        self::assertSame($profileRepository, $namedArgumentProfileRepository);
     }
 
     private function compileContainer(ContainerBuilder $container, array $config): void


### PR DESCRIPTION
This patch enables injecting aggregate repositories directly if the variable name matches the aggregateName.

Before:
```php
#[AsController]
final readonly class HotelController
{
    private Repository $hotelRepository,

    public function __construct(
        RepositoryManager $repositoryManager,
    ) {
        $this->hotelRepository = $repositoryManager->get(Hotel::class);
    }
}
```

After:
```php
#[AsController]
final readonly class HotelController
{
    public function __construct(
        private Repository $hotelRepository,
    ) {
    }
}
```