### PR TITLE
Add auto configuring for custom ArgumentResolvers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "patchlevel/event-sourcing": "^3.0.0",
+    "patchlevel/event-sourcing": "^3.1.0",
     "symfony/cache": "^6.4.0|^7.0.0",
     "symfony/config": "^6.4.0|^7.0.0",
     "symfony/console": "^6.4.1|^7.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4564c13ff5cc4011696e16eb27f82a0",
+    "content-hash": "4a939e387d3725ee125b971070de97a8",
     "packages": [
         {
             "name": "brick/math",
@@ -416,16 +416,16 @@
         },
         {
             "name": "patchlevel/event-sourcing",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/patchlevel/event-sourcing.git",
-                "reference": "ccdfccc20051fb37c9e2b490bb102b6a86ce9a59"
+                "reference": "ea4ee7aacff666c31724ad7687be14e3ceaf2771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/patchlevel/event-sourcing/zipball/ccdfccc20051fb37c9e2b490bb102b6a86ce9a59",
-                "reference": "ccdfccc20051fb37c9e2b490bb102b6a86ce9a59",
+                "url": "https://api.github.com/repos/patchlevel/event-sourcing/zipball/ea4ee7aacff666c31724ad7687be14e3ceaf2771",
+                "reference": "ea4ee7aacff666c31724ad7687be14e3ceaf2771",
                 "shasum": ""
             },
             "require": {
@@ -486,16 +486,16 @@
                 }
             ],
             "description": "A lightweight but also all-inclusive event sourcing library with a focus on developer experience",
-            "homepage": "https://github.com/patchlevel/event-sourcing",
+            "homepage": "https://event-sourcing.patchlevel.io",
             "keywords": [
                 "ddd",
                 "event-sourcing"
             ],
             "support": {
                 "issues": "https://github.com/patchlevel/event-sourcing/issues",
-                "source": "https://github.com/patchlevel/event-sourcing/tree/3.0.0"
+                "source": "https://github.com/patchlevel/event-sourcing/tree/3.1.0"
             },
-            "time": "2024-04-26T14:55:43+00:00"
+            "time": "2024-07-03T11:52:53+00:00"
         },
         {
             "name": "patchlevel/hydrator",

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -98,6 +98,7 @@ use Patchlevel\EventSourcing\Subscription\RetryStrategy\ClockBasedRetryStrategy;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategy;
 use Patchlevel\EventSourcing\Subscription\Store\DoctrineSubscriptionStore;
 use Patchlevel\EventSourcing\Subscription\Store\SubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\ArgumentResolver;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberHelper;
@@ -312,10 +313,14 @@ final class PatchlevelEventSourcingExtension extends Extension
 
         $container->setAlias(SubscriptionStore::class, DoctrineSubscriptionStore::class);
 
+        $container->registerForAutoconfiguration(ArgumentResolver::class)
+            ->addTag('event_sourcing.argument_resolver');
+
         $container->register(MetadataSubscriberAccessorRepository::class)
             ->setArguments([
                 new TaggedIteratorArgument('event_sourcing.subscriber'),
                 new Reference(SubscriberMetadataFactory::class),
+                new TaggedIteratorArgument('event_sourcing.argument_resolver'),
             ]);
 
         $container->setAlias(SubscriberAccessorRepository::class, MetadataSubscriberAccessorRepository::class);

--- a/tests/Fixtures/DummyArgumentResolver.php
+++ b/tests/Fixtures/DummyArgumentResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Patchlevel\EventSourcingBundle\Tests\Fixtures;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\ArgumentResolver;
+
+class DummyArgumentResolver implements ArgumentResolver
+{
+    public function resolve(ArgumentMetadata $argument, Message $message): mixed
+    {
+        return null;
+    }
+
+    public function support(ArgumentMetadata $argument, string $eventClass): bool
+    {
+        return false;
+    }
+
+}

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -29,9 +29,6 @@ use Patchlevel\EventSourcing\Console\Command\SubscriptionTeardownCommand;
 use Patchlevel\EventSourcing\Console\Command\WatchCommand;
 use Patchlevel\EventSourcing\Debug\Trace\TraceStack;
 use Patchlevel\EventSourcing\EventBus\ChainEventBus;
-use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
-use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
-use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\EventBus\Psr14EventBus;
@@ -39,6 +36,9 @@ use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
+use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
+use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
+use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaProvider;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaSubscriber;
@@ -53,9 +53,11 @@ use Patchlevel\EventSourcing\Subscription\Engine\CatchUpSubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\DefaultSubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineRepositoryManager;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
 use Patchlevel\EventSourcingBundle\DependencyInjection\PatchlevelEventSourcingExtension;
 use Patchlevel\EventSourcingBundle\EventBus\SymfonyEventBus;
 use Patchlevel\EventSourcingBundle\PatchlevelEventSourcingBundle;
+use Patchlevel\EventSourcingBundle\Tests\Fixtures\DummyArgumentResolver;
 use Patchlevel\EventSourcingBundle\Tests\Fixtures\Listener1;
 use Patchlevel\EventSourcingBundle\Tests\Fixtures\Listener2;
 use Patchlevel\EventSourcingBundle\Tests\Fixtures\Profile;
@@ -73,6 +75,7 @@ use Psr\Clock\ClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -678,6 +681,30 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertTrue($container->getDefinition(ProfileSubscriber::class)->hasTag('event_sourcing.subscriber'));
         self::assertTrue($container->getDefinition(ProfileProcessor::class)->hasTag('event_sourcing.subscriber'));
         self::assertTrue($container->getDefinition(ProfileProjector::class)->hasTag('event_sourcing.subscriber'));
+    }
+
+    public function testAutoconfigureArgumentResolver(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->setDefinition(DummyArgumentResolver::class, new Definition(DummyArgumentResolver::class))
+            ->setAutoconfigured(true)
+            ;
+
+        $this->compileContainer(
+            $container,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'service' => 'doctrine.dbal.eventstore_connection',
+                    ],
+                ],
+            ]
+        );
+
+        self::assertTrue($container->getDefinition(DummyArgumentResolver::class)->hasTag('event_sourcing.argument_resolver'));
+        self::assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition(MetadataSubscriberAccessorRepository::class)->getArgument(2));
+        self::assertEquals('event_sourcing.argument_resolver', $container->getDefinition(MetadataSubscriberAccessorRepository::class)->getArgument(2)->getTag());
     }
 
     public function testSchemaMerge(): void


### PR DESCRIPTION
This adds auto configuration of ArgumentResolvers with a new tag event_subscriber.argument_resolver that is added to all classes implementing the ArgumentResolver.

This requires an update of the library to allow iterables in the configuration.
