### PR TITLE
Use the listener instead of deprecated subscriber

### DIFF
--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -74,8 +74,8 @@ use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
 use Patchlevel\EventSourcing\Schema\DoctrineMigrationSchemaProvider;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaConfigurator;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaListener;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaProvider;
-use Patchlevel\EventSourcing\Schema\DoctrineSchemaSubscriber;
 use Patchlevel\EventSourcing\Schema\SchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Serializer\Encoder\Encoder;
@@ -741,7 +741,7 @@ final class PatchlevelEventSourcingExtension extends Extension
         $container->setAlias(DoctrineSchemaConfigurator::class, ChainDoctrineSchemaConfigurator::class);
 
         if ($config['store']['merge_orm_schema']) {
-            $container->register(DoctrineSchemaSubscriber::class)
+            $container->register(DoctrineSchemaListener::class)
                 ->setArguments([new Reference(DoctrineSchemaConfigurator::class)])
                 ->addTag('doctrine.event_listener', ['event' => ToolEvents::postGenerateSchema]);
 

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -40,8 +40,8 @@ use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\Repository\RepositoryManager;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaListener;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaProvider;
-use Patchlevel\EventSourcing\Schema\DoctrineSchemaSubscriber;
 use Patchlevel\EventSourcing\Schema\SchemaDirector;
 use Patchlevel\EventSourcing\Snapshot\Adapter\Psr16SnapshotAdapter;
 use Patchlevel\EventSourcing\Snapshot\Adapter\Psr6SnapshotAdapter;
@@ -725,7 +725,7 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
             ]
         );
 
-        self::assertInstanceOf(DoctrineSchemaSubscriber::class, $container->get(DoctrineSchemaSubscriber::class));
+        self::assertInstanceOf(DoctrineSchemaListener::class, $container->get(DoctrineSchemaListener::class));
         self::assertFalse($container->has(SchemaDirector::class));
         self::assertFalse($container->has(DoctrineSchemaProvider::class));
         self::assertFalse($container->has(DatabaseCreateCommand::class));


### PR DESCRIPTION
This fixes the psalm error which was also reported here https://github.com/patchlevel/event-sourcing-bundle/pull/211#pullrequestreview-2156993742