### PR TITLE
Custom headers configuration

### DIFF
--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -55,6 +55,28 @@ patchlevel_event_sourcing:
 !!! tip
 
     If you want to learn more about events, read the [library documentation](https://patchlevel.github.io/event-sourcing-docs/latest/events/).
+
+## Custom Headers
+
+If you want to implement custom headers for your application, you must specify the
+paths to look for those headers.
+If you want you can use glob patterns to specify multiple paths.
+
+```yaml
+patchlevel_event_sourcing:
+  headers: '%kernel.project_dir%/src/*/Domain/Header'
+```
+Or use an array to specify multiple paths.
+
+```yaml
+patchlevel_event_sourcing:
+  events:
+    - '%kernel.project_dir%/src/Hotel/Domain/Header'
+    - '%kernel.project_dir%/src/Room/Domain/Header'
+```
+!!! tip
+
+    If you want to learn more about custom headers, read the [library documentation](https://event-sourcing.patchlevel.io/latest/message/#custom-headers).
     
 ## Connection
 

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -70,7 +70,7 @@ Or use an array to specify multiple paths.
 
 ```yaml
 patchlevel_event_sourcing:
-  events:
+  headers:
     - '%kernel.project_dir%/src/Hotel/Domain/Header'
     - '%kernel.project_dir%/src/Room/Domain/Header'
 ```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *      store: array{merge_orm_schema: bool, options: array<string, mixed>},
  *      aggregates: list<string>,
  *      events: list<string>,
+ *      headers: list<string>,
  *      snapshot_stores: array<string, array{type: string, service: string}>,
  *      migration: array{path: string, namespace: string},
  *      cryptography: array{enabled: bool, algorithm: string},
@@ -85,6 +86,12 @@ final class Configuration implements ConfigurationInterface
             ->end()
 
             ->arrayNode('aggregates')
+                ->beforeNormalization()->castToArray()->end()
+                ->defaultValue([])
+                ->scalarPrototype()->end()
+            ->end()
+
+            ->arrayNode('headers')
                 ->beforeNormalization()->castToArray()->end()
                 ->defaultValue([])
                 ->scalarPrototype()->end()

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -196,7 +196,7 @@ final class PatchlevelEventSourcingExtension extends Extension
 
         $container->register(MessageHeaderRegistry::class)
             ->setFactory([new Reference(MessageHeaderRegistryFactory::class), 'create'])
-            ->setArguments([[]]);
+            ->setArguments([$config['headers']]);
 
         $container->register(DefaultHeadersSerializer::class)
             ->setArguments([

--- a/tests/Fixtures/CustomHeader.php
+++ b/tests/Fixtures/CustomHeader.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Patchlevel\EventSourcingBundle\Tests\Fixtures;
+
+use Patchlevel\EventSourcing\Attribute\Header;
+
+#[Header('custom')]
+class CustomHeader
+{
+    public function __construct(
+        readonly string $value
+    ) {}
+}

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -28,15 +28,12 @@ use Patchlevel\EventSourcing\Console\Command\SubscriptionStatusCommand;
 use Patchlevel\EventSourcing\Console\Command\SubscriptionTeardownCommand;
 use Patchlevel\EventSourcing\Console\Command\WatchCommand;
 use Patchlevel\EventSourcing\Debug\Trace\TraceStack;
-use Patchlevel\EventSourcing\Metadata\Message\MessageHeaderRegistry;
-use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
-use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
-use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\EventBus\Psr14EventBus;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Metadata\Message\MessageHeaderRegistry;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
@@ -681,7 +678,6 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
             $container->get(SubscriptionEngine::class));
     }
 
-
     public function testAutoconfigureSubscriber(): void
     {
         $container = new ContainerBuilder();
@@ -717,7 +713,7 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
 
         $container->setDefinition(DummyArgumentResolver::class, new Definition(DummyArgumentResolver::class))
             ->setAutoconfigured(true)
-            ;
+        ;
 
         $this->compileContainer(
             $container,
@@ -864,6 +860,7 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertInstanceOf(RepositoryManager::class, $container->get(RepositoryManager::class));
         self::assertInstanceOf(EventRegistry::class, $container->get(EventRegistry::class));
     }
+
     public function testNamedRepository(): void
     {
         $container = new ContainerBuilder();
@@ -911,4 +908,5 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
 
         $container->compile();
     }
+
 }

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -28,6 +28,7 @@ use Patchlevel\EventSourcing\Console\Command\SubscriptionStatusCommand;
 use Patchlevel\EventSourcing\Console\Command\SubscriptionTeardownCommand;
 use Patchlevel\EventSourcing\Console\Command\WatchCommand;
 use Patchlevel\EventSourcing\Debug\Trace\TraceStack;
+use Patchlevel\EventSourcing\Metadata\Message\MessageHeaderRegistry;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
@@ -55,6 +56,7 @@ use Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineReposi
 use Patchlevel\EventSourcingBundle\DependencyInjection\PatchlevelEventSourcingExtension;
 use Patchlevel\EventSourcingBundle\EventBus\SymfonyEventBus;
 use Patchlevel\EventSourcingBundle\PatchlevelEventSourcingBundle;
+use Patchlevel\EventSourcingBundle\Tests\Fixtures\CustomHeader;
 use Patchlevel\EventSourcingBundle\Tests\Fixtures\Listener1;
 use Patchlevel\EventSourcingBundle\Tests\Fixtures\Listener2;
 use Patchlevel\EventSourcingBundle\Tests\Fixtures\Profile;
@@ -430,6 +432,29 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
 
         self::assertInstanceOf(AggregateRootRegistry::class, $aggregateRegistry);
         self::assertTrue($aggregateRegistry->hasAggregateClass(Profile::class));
+    }
+
+    public function testMessageHeaderRegistry(): void
+    {
+        $container = new ContainerBuilder();
+
+        $this->compileContainer(
+            $container,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'service' => 'doctrine.dbal.eventstore_connection',
+                    ],
+                    'headers' => [__DIR__ . '/../Fixtures'],
+                ],
+            ]
+        );
+
+        /** @var MessageHeaderRegistry $messageHeaderRegistry */
+        $messageHeaderRegistry = $container->get(MessageHeaderRegistry::class);
+
+        self::assertInstanceOf(MessageHeaderRegistry::class, $messageHeaderRegistry);
+        self::assertTrue($messageHeaderRegistry->hasHeaderClass(CustomHeader::class));
     }
 
     public function testRepositoryManager(): void


### PR DESCRIPTION
This makes it easier to add custom headers in your project.

The PR is against 3.0.x and can be safely applied to all branches as it only adds a new configuration key and does not break anything and brings no mandatory changes to your code base.

I also added a few words in the docs about this.
