### PR TITLE
Fix documentation of configuring `table_name`

### DIFF
--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -107,7 +107,8 @@ You can change the table name of the event store.
 ```yaml
 patchlevel_event_sourcing:
     store:
-        table_name: 'my_event_store'
+        options:
+            table_name: 'my_event_store'
 ```
 ### Merge ORM Schema
 


### PR DESCRIPTION
This example references the setting `store.table_name`, but using this setting causes an error to be emitted.

```
Unrecognized option "table_name" under "patchlevel_event_sourcing.store". Available
options are "merge_orm_schema", "options".
```

It appears this example should reference `store.options.table_name` instead; doing so avoids the above error. This also appears to be corroborated by discrepancies elsewhere in the codebase, specifically [here](https://github.com/patchlevel/event-sourcing-bundle/blob/3b48caeaaa4a685d8cfb3aa300599b277fd0dd29/src/DependencyInjection/Configuration.php#L31) and [here](https://github.com/patchlevel/event-sourcing-bundle/blob/3b48caeaaa4a685d8cfb3aa300599b277fd0dd29/tests/Unit/PatchlevelEventSourcingBundleTest.php#L818-L822).