### PR TITLE
Subscriber Connection Guard

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="src/DependencyInjection/Configuration.php">
-    <PossiblyNullReference>
-      <code>scalarNode</code>
-    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
-      <code>scalarNode</code>
+      <code><![CDATA[scalarNode]]></code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="src/DependencyInjection/PatchlevelEventSourcingExtension.php">
-    <DeprecatedClass>
-      <code>DoctrineSchemaManager::class</code>
-      <code>DoctrineSchemaManager::class</code>
-      <code>MetadataAwareProjectionHandler::class</code>
-      <code>MetadataAwareProjectionHandler::class</code>
-      <code>ProjectionListener::class</code>
-    </DeprecatedClass>
+  <file src="src/DependencyInjection/SubscriberGuardCompilePass.php">
+    <InvalidOperand>
+      <code><![CDATA[$index]]></code>
+    </InvalidOperand>
+    <MixedAssignment>
+      <code><![CDATA[$argument]]></code>
+    </MixedAssignment>
   </file>
 </files>

--- a/src/DependencyInjection/SubscriberGuardCompilePass.php
+++ b/src/DependencyInjection/SubscriberGuardCompilePass.php
@@ -61,7 +61,7 @@ final class SubscriberGuardCompilePass implements CompilerPassInterface
 
                 throw new InvalidArgumentException(
                     sprintf(
-                        'You cannot use the same connection for event sourcing and your subscription.%s',
+                        'Using the same database connection for the eventstore and projections is not allowed. This configuration may result in transaction conflicts due to DDL operations, leading to system instability. Please use separate connections for the eventstore and projections to ensure safe operation. %s',
                         $context,
                     ),
                 );

--- a/src/DependencyInjection/SubscriberGuardCompilePass.php
+++ b/src/DependencyInjection/SubscriberGuardCompilePass.php
@@ -61,7 +61,7 @@ final class SubscriberGuardCompilePass implements CompilerPassInterface
 
                 throw new InvalidArgumentException(
                     sprintf(
-                        'Using the same database connection for the eventstore and projections is not allowed. This configuration may result in transaction conflicts due to DDL operations, leading to system instability. Please use separate connections for the eventstore and projections to ensure safe operation. %s',
+                        'Using the same database connection for the eventstore and projections is not allowed. This configuration may result in transaction conflicts due to DDL operations, leading to system instability. Please use separate connections for the eventstore and projections to ensure safe operation.%s',
                         $context,
                     ),
                 );

--- a/src/DependencyInjection/SubscriberGuardCompilePass.php
+++ b/src/DependencyInjection/SubscriberGuardCompilePass.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\DependencyInjection;
+
+use Patchlevel\EventSourcing\Subscription\Store\DoctrineSubscriptionStore;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
+use function array_keys;
+use function sprintf;
+
+final class SubscriberGuardCompilePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(DoctrineSubscriptionStore::class)) {
+            return;
+        }
+
+        $definition = $container->getDefinition(DoctrineSubscriptionStore::class);
+
+        $argument = $definition->getArgument(0);
+
+        if (!$argument instanceof Reference) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The first argument of the "%s" service must be a reference.',
+                    DoctrineSubscriptionStore::class,
+                ),
+            );
+        }
+
+        $subscriptionConnection = $this->resolveService($container, (string)$argument);
+
+        $subscribers = $container->findTaggedServiceIds('event_sourcing.subscriber');
+
+        foreach (array_keys($subscribers) as $id) {
+            $definition = $container->getDefinition($id);
+
+            $arguments = $definition->getArguments();
+
+            foreach ($arguments as $index => $argument) {
+                if (!$argument instanceof Reference) {
+                    continue;
+                }
+
+                if ($subscriptionConnection !== $this->resolveService($container, (string)$argument)) {
+                    continue;
+                }
+
+                $class = $definition->getClass();
+                $context = '';
+
+                if ($class !== null) {
+                    $context = sprintf(' Argument %s on class %s.', $index + 1, $class);
+                }
+
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'You cannot use the same connection for event sourcing and your subscription.%s',
+                        $context,
+                    ),
+                );
+            }
+        }
+    }
+
+    private function resolveService(ContainerBuilder $container, string $id): string
+    {
+        if ($container->hasAlias($id)) {
+            return $this->resolveService(
+                $container,
+                (string)$container->getAlias($id),
+            );
+        }
+
+        return $id;
+    }
+}

--- a/src/PatchlevelEventSourcingBundle.php
+++ b/src/PatchlevelEventSourcingBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcingBundle;
 
 use Patchlevel\EventSourcingBundle\DependencyInjection\RepositoryCompilerPass;
+use Patchlevel\EventSourcingBundle\DependencyInjection\SubscriberGuardCompilePass;
 use Patchlevel\EventSourcingBundle\DependencyInjection\TraceCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -15,5 +16,6 @@ final class PatchlevelEventSourcingBundle extends Bundle
     {
         $container->addCompilerPass(new TraceCompilerPass());
         $container->addCompilerPass(new RepositoryCompilerPass());
+        $container->addCompilerPass(new SubscriberGuardCompilePass());
     }
 }

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -811,7 +811,7 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
             ->setAutoconfigured(true);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('You cannot use the same connection for event sourcing and your subscription. Argument 1 on class Patchlevel\EventSourcingBundle\Tests\Fixtures\ProfileProjector.');
+        $this->expectExceptionMessage('Using the same database connection for the eventstore and projections is not allowed. This configuration may result in transaction conflicts due to DDL operations, leading to system instability. Please use separate connections for the eventstore and projections to ensure safe operation. Argument 1 on class Patchlevel\EventSourcingBundle\Tests\Fixtures\ProfileProjector.');
 
         $this->compileContainer(
             $container,

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -87,6 +87,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final class PatchlevelEventSourcingBundleTest extends TestCase
@@ -797,6 +798,31 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
 
         self::assertInstanceOf(CatchUpSubscriptionEngine::class,
             $container->get(SubscriptionEngine::class));
+    }
+
+    public function testSubscriberSameConnectionError(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->setDefinition(ProfileProjector::class, new Definition(
+            ProfileProjector::class,
+            [new Reference('doctrine.dbal.eventstore_connection')]
+        ))
+            ->setAutoconfigured(true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot use the same connection for event sourcing and your subscription. Argument 1 on class Patchlevel\EventSourcingBundle\Tests\Fixtures\ProfileProjector.');
+
+        $this->compileContainer(
+            $container,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'service' => 'doctrine.dbal.eventstore_connection',
+                    ],
+                ],
+            ]
+        );
     }
 
     public function testAutoconfigureSubscriber(): void


### PR DESCRIPTION
Add a compiler pass that makes sure you do not use the same connection for your projection to avoid errors