### PR TITLE
copy connection for projection

### DIFF
--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -92,6 +92,30 @@ patchlevel_event_sourcing:
     You can find out more about how to create a connection 
     [here](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html)
     
+### Connection for Projections
+
+Per default, our event sourcing connection is not available to use in your application.
+But you can create a dedicated connection that you can use for your projections.
+
+```yaml
+patchlevel_event_sourcing:
+  connection:
+    url: '%env(EVENTSTORE_URL)%'
+    provide_dedicated_connection: true
+```
+!!! tip
+
+    You can autowire the connection in your services like this:
+    
+    ```php
+    use Doctrine\DBAL\Connection;
+    
+    public function __construct(
+        private readonly Connection $projectionConnection,
+    ) {
+    }
+    ```
+    
 ### Doctrine Bundle
 
 If you have installed the [doctrine bundle](https://github.com/doctrine/DoctrineBundle),
@@ -108,6 +132,11 @@ patchlevel_event_sourcing:
     connection:
         service: doctrine.dbal.eventstore_connection
 ```
+!!! danger
+
+    Do not use the same connection for event sourcing and your projections,
+    otherwise you may run into transaction problems.
+    
 !!! warning
 
     If you want to use the same connection as doctrine orm, then you have to set the flag `merge_orm_schema`. 
@@ -118,6 +147,42 @@ patchlevel_event_sourcing:
     You can find out more about the dbal configuration 
     [here](https://symfony.com/bundles/DoctrineBundle/current/configuration.html).
     
+If you are using Doctrine for your projections too, you need to create a dedicated connection for this.
+You can do this by defining a new connection named `projection` in the `doctrine.yaml` file
+and use the same connection url as for the event store.
+
+```yaml
+doctrine:
+    dbal:
+        connections:
+            eventstore:
+                url: '%env(EVENTSTORE_URL)%'
+            projection:
+                url: '%env(EVENTSTORE_URL)%'
+
+patchlevel_event_sourcing:
+    connection:
+        service: doctrine.dbal.eventstore_connection
+```
+Then you can use this connection in your projections.
+If you are using autowiring you can inject the right connection `Connection $projectionConnection` parameter name.
+The prefix `projection` is used to identify the connection.
+
+```php
+namespace App\Projection;
+
+use Doctrine\DBAL\Connection;
+use Patchlevel\EventSourcing\Attribute\Projector;
+
+#[Projector('my_projection')]
+class MyProjection
+{
+    public function __construct(
+        private readonly Connection $projectionConnection,
+    ) {
+    }
+}
+```
 ## Store
 
 The store and schema is configurable.
@@ -200,12 +265,12 @@ patchlevel_event_sourcing:
 
     You can find out more about subscriptions in the library 
     [documentation](https://event-sourcing.patchlevel.io/latest/subscription/).
-
+    
 ### Store
 
-You can change where the subscription engine stores its necessary information about the subscription. 
-Default is `dbal`, which means it stores it in the same DB that is used by the dbal event store. 
-Otherwise you also have the option to set it to `in_memory`, then this information will not be persisted anywhere. 
+You can change where the subscription engine stores its necessary information about the subscription.
+Default is `dbal`, which means it stores it in the same DB that is used by the dbal event store.
+Otherwise you also have the option to set it to `in_memory`, then this information will not be persisted anywhere.
 This is very useful for testing. And if that is not enough, you can also define a `custom` store and specify the service.
 
 ```yaml
@@ -215,7 +280,6 @@ patchlevel_event_sourcing:
       type: 'custom' # default is 'dbal'
       service: 'my_subscription_store'
 ```
-
 ### Catch Up
 
 If aggregates are used in the processors and new events are generated there,

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -194,8 +194,9 @@ final class HotelProjection
 {
     use SubscriberUtil;
 
-    public function __construct(private Connection $db)
-    {
+    public function __construct(
+        private Connection $projectionConnection,
+    ) {
     }
 
     /** @return list<array{id: string, name: string, guests: int}> */

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -36,6 +36,7 @@ patchlevel_event_sourcing:
     events: '%kernel.project_dir%/src'
     connection:
       url: '%env(EVENTSTORE_URL)%'
+      provide_dedicated_connection: true
 
 when@dev:
   patchlevel_event_sourcing:
@@ -63,7 +64,7 @@ EVENTSTORE_URL="pdo-pgsql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&c
 !!! note
 
     You can find out more about what a connection url looks like [here](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url).
-
+    
 ## Database with Docker
 
 If you are using docker, you can use the following `compose.yaml` file to start a postgres database.
@@ -85,7 +86,6 @@ services:
 volumes:
   eventstore_data:
 ```
-
 And for development, you can add a `compose.override.yaml` file to expose the port.
 
 ```yaml
@@ -94,10 +94,9 @@ services:
     ports:
       - "5432"
 ```
-
 ## Symfony CLI
 
-If you are using the [symfony cli](https://symfony.com/download), 
+If you are using the [symfony cli](https://symfony.com/download),
 you can configure that the database is started automatically if you start the server.
 For this you have to add the following configuration to the `.symfony.local.yaml` file.
 
@@ -105,7 +104,6 @@ For this you have to add the following configuration to the `.symfony.local.yaml
 workers:
   docker_compose: ~
 ```
-
 !!! success
 
     You have successfully installed the bundle. Now you can start with the [quickstart](./getting_started.md) to get a feeling for the bundle.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *      connection: ?array{
  *          service: ?string,
  *          url: ?string,
- *          projection: bool
+ *          provide_dedicated_connection: bool
  *      },
  *      store: array{merge_orm_schema: bool, options: array<string, mixed>, type: string, service: ?string},
  *      aggregates: list<string>,
@@ -61,7 +61,7 @@ final class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('service')->defaultNull()->end()
                     ->scalarNode('url')->defaultNull()->end()
-                    ->booleanNode('projection')->defaultFalse()->end()
+                    ->booleanNode('provide_dedicated_connection')->defaultFalse()->end()
                 ->end()
             ->end()
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,7 +28,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *           },
  *          rebuild_after_file_change: bool
  *      },
- *      connection: ?array{service: ?string, url: ?string},
+ *      connection: ?array{
+ *          service: ?string,
+ *          url: ?string,
+ *          projection: bool
+ *      },
  *      store: array{merge_orm_schema: bool, options: array<string, mixed>, type: string, service: ?string},
  *      aggregates: list<string>,
  *      events: list<string>,
@@ -57,6 +61,7 @@ final class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('service')->defaultNull()->end()
                     ->scalarNode('url')->defaultNull()->end()
+                    ->booleanNode('projection')->defaultFalse()->end()
                 ->end()
             ->end()
 

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -470,11 +470,25 @@ final class PatchlevelEventSourcingExtension extends Extension
                     $config['connection']['url'],
                 ]);
 
+            if ($config['connection']['projection']) {
+                $container->register('event_sourcing.dbal_projection_connection', Connection::class)
+                    ->setFactory([DbalConnectionFactory::class, 'createConnection'])
+                    ->setArguments([
+                        $config['connection']['url'],
+                    ]);
+
+                $container->setAlias(Connection::class, 'event_sourcing.dbal_projection_connection');
+            }
+
             return;
         }
 
         if ($config['connection']['service'] === null) {
-            return;
+            throw new InvalidArgumentException('Connection service or url is required');
+        }
+
+        if ($config['connection']['projection']) {
+            throw new InvalidArgumentException('Projection connection is only supported with url');
         }
 
         $container->setAlias('event_sourcing.dbal_connection', $config['connection']['service']);

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -470,14 +470,14 @@ final class PatchlevelEventSourcingExtension extends Extension
                     $config['connection']['url'],
                 ]);
 
-            if ($config['connection']['projection']) {
-                $container->register('event_sourcing.dbal_projection_connection', Connection::class)
+            if ($config['connection']['provide_dedicated_connection']) {
+                $container->register('event_sourcing.dbal_public_connection', Connection::class)
                     ->setFactory([DbalConnectionFactory::class, 'createConnection'])
                     ->setArguments([
                         $config['connection']['url'],
                     ]);
 
-                $container->setAlias(Connection::class, 'event_sourcing.dbal_projection_connection');
+                $container->setAlias(Connection::class, 'event_sourcing.dbal_public_connection');
             }
 
             return;
@@ -487,8 +487,8 @@ final class PatchlevelEventSourcingExtension extends Extension
             throw new InvalidArgumentException('Connection service or url is required');
         }
 
-        if ($config['connection']['projection']) {
-            throw new InvalidArgumentException('Projection connection is only supported with url');
+        if ($config['connection']['provide_dedicated_connection']) {
+            throw new InvalidArgumentException('Providing dedicated connection is only possible with url');
         }
 
         $container->setAlias('event_sourcing.dbal_connection', $config['connection']['service']);

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -161,14 +161,14 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
                 'patchlevel_event_sourcing' => [
                     'connection' => [
                         'url' => 'sqlite3:///:memory:',
-                        'projection' => true,
+                        'provide_dedicated_connection' => true,
                     ],
                 ],
             ]
         );
 
         $eventSourcingConnection = $container->get('event_sourcing.dbal_connection');
-        $projectionConnection = $container->get('event_sourcing.dbal_projection_connection');
+        $projectionConnection = $container->get('event_sourcing.dbal_public_connection');
 
         self::assertInstanceOf(Connection::class, $eventSourcingConnection);
         self::assertInstanceOf(Connection::class, $projectionConnection);

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -152,6 +152,30 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertInstanceOf(DoctrineDbalStore::class, $container->get(Store::class));
     }
 
+    public function testProjectionConnection(): void
+    {
+        $container = new ContainerBuilder();
+        $this->compileContainer(
+            $container,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'url' => 'sqlite3:///:memory:',
+                        'projection' => true,
+                    ],
+                ],
+            ]
+        );
+
+        $eventSourcingConnection = $container->get('event_sourcing.dbal_connection');
+        $projectionConnection = $container->get('event_sourcing.dbal_projection_connection');
+
+        self::assertInstanceOf(Connection::class, $eventSourcingConnection);
+        self::assertInstanceOf(Connection::class, $projectionConnection);
+
+        self::assertNotSame($eventSourcingConnection, $projectionConnection);
+    }
+
     public function testCustomStore(): void
     {
         $store = $this->prophesize(Store::class)->reveal();


### PR DESCRIPTION
During the tutorial I discovered that you can use the event store and subscription engine without Doctrine Bundle. But as soon as you want to write your projections with dbal, you have to install DoctrineBundle or set up the connection yourself.
(You cannot use the same connection as the one for event sourcing, otherwise the subscription engine will break)

So you currently have the following options:

1) You build a connection service yourself, which is cumbersome.

2) You install DoctrineBundle, but you immediately get an error message that the orm package is missing and you have to remove orm config first.

<img width="664" alt="Bildschirmfoto 2024-12-05 um 11 13 59" src="https://github.com/user-attachments/assets/9e22e6d7-9f3a-41f0-8d22-2a0ba199515e">




We recommend using DoctrineBundle if you want all the Dbal features like extended configuration options, logger and profiler. But for the start and tutorial it is unfortunate.

I also didn't want to duplicate the features of DoctrineBundle here. That wouldn't make sense.

I also looked to see if our bundle should require DoctrineBundle directly, but that isn't that easy to implement either, as we would have to manipulate the config. It could also be that you don't want to use dbal then we could have saved ourselves that.

So I came up with the simple solution of offering the option to build a second connection with the same URL, which you can then use in your projection. That is the simplest solution without having to go through DoctrineBundle.

The naming of the option is not good yet. Here are a few ideas:

* use_for_projection
* publish_connection