### PR TITLE
dont skip rebuild, if subscription is unknown

### DIFF
--- a/src/RequestListener/SubscriptionRebuildAfterFileChangeListener.php
+++ b/src/RequestListener/SubscriptionRebuildAfterFileChangeListener.php
@@ -44,13 +44,6 @@ final class SubscriptionRebuildAfterFileChangeListener
 
             $item = $this->cache->getItem($metadata->id);
 
-            if (!$item->isHit()) {
-                $item->set($this->getLastModifiedTime($subscriber));
-                $this->cache->save($item);
-
-                continue;
-            }
-
             /** @var int|null $lastModified */
             $lastModified = $item->get();
             $currentModified = $this->getLastModifiedTime($subscriber);


### PR DESCRIPTION
When the subscription appears for the first time, e.g. when you copy it, it is unknown to the rebuild listener.
The subscription will be skipped. Only when you change the subscription again, the listener know the subscriber an the rebuild will be executed. That makes no sense and has been fixed with this pr.