### PR TITLE
allow initialize in memory store statically

### DIFF
--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -270,8 +270,13 @@ patchlevel_event_sourcing:
 
 You can change where the subscription engine stores its necessary information about the subscription.
 Default is `dbal`, which means it stores it in the same DB that is used by the dbal event store.
-Otherwise you also have the option to set it to `in_memory`, then this information will not be persisted anywhere.
-This is very useful for testing. And if that is not enough, you can also define a `custom` store and specify the service.
+
+Otherwise you can choose between the following stores:
+
+- `dbal` *default*
+- `in_memory`
+- `static_in_memory`
+- `custom`
 
 ```yaml
 patchlevel_event_sourcing:
@@ -280,6 +285,12 @@ patchlevel_event_sourcing:
       type: 'custom' # default is 'dbal'
       service: 'my_subscription_store'
 ```
+
+!!! tip
+
+    If you are using the [doctrine-test-bundle](https://github.com/dmaicher/doctrine-test-bundle),
+    you can use the `static_in_memory` store for testing.
+
 ### Catch Up
 
 If aggregates are used in the processors and new events are generated there,

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -146,7 +146,7 @@ final class Configuration implements ConfigurationInterface
                         ->addDefaultsIfNotSet()
                         ->children()
                             ->enumNode('type')
-                                ->values(['dbal', 'in_memory', 'custom'])
+                                ->values(['dbal', 'in_memory', 'static_in_memory', 'custom'])
                                 ->defaultValue('dbal')
                             ->end()
                             ->scalarNode('service')->defaultNull()->end()

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -109,6 +109,7 @@ use Patchlevel\EventSourcingBundle\Doctrine\DbalConnectionFactory;
 use Patchlevel\EventSourcingBundle\EventBus\SymfonyEventBus;
 use Patchlevel\EventSourcingBundle\RequestListener\AutoSetupListener;
 use Patchlevel\EventSourcingBundle\RequestListener\SubscriptionRebuildAfterFileChangeListener;
+use Patchlevel\EventSourcingBundle\Subscription\StaticInMemorySubscriptionStoreFactory;
 use Patchlevel\EventSourcingBundle\ValueResolver\AggregateRootIdValueResolver;
 use Patchlevel\Hydrator\Cryptography\Cipher\Cipher;
 use Patchlevel\Hydrator\Cryptography\Cipher\CipherKeyFactory;
@@ -312,6 +313,10 @@ final class PatchlevelEventSourcingExtension extends Extension
             $container->setAlias(SubscriptionStore::class, $config['subscription']['store']['service']);
         } elseif ($config['subscription']['store']['type'] === 'in_memory') {
             $container->register(InMemorySubscriptionStore::class);
+            $container->setAlias(SubscriptionStore::class, InMemorySubscriptionStore::class);
+        } elseif ($config['subscription']['store']['type'] === 'static_in_memory') {
+            $container->register(InMemorySubscriptionStore::class)
+                ->setFactory([StaticInMemorySubscriptionStoreFactory::class, 'create']);
             $container->setAlias(SubscriptionStore::class, InMemorySubscriptionStore::class);
         } elseif ($config['subscription']['store']['type'] === 'dbal') {
             $container->register(DoctrineSubscriptionStore::class)

--- a/src/Subscription/StaticInMemorySubscriptionStoreFactory.php
+++ b/src/Subscription/StaticInMemorySubscriptionStoreFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\Subscription;
+
+use Patchlevel\EventSourcing\Subscription\Store\InMemorySubscriptionStore;
+
+final class StaticInMemorySubscriptionStoreFactory
+{
+    private static InMemorySubscriptionStore|null $store = null;
+
+    public static function create(): InMemorySubscriptionStore
+    {
+        if (self::$store === null) {
+            self::$store = new InMemorySubscriptionStore();
+        }
+
+        return self::$store;
+    }
+}

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -799,6 +799,49 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertInstanceOf(InMemorySubscriptionStore::class, $container->get(SubscriptionStore::class));
     }
 
+    public function testSubscriptionEngineStaticInMemoryStore(): void
+    {
+        $containerA = new ContainerBuilder();
+        $containerB = new ContainerBuilder();
+
+        $this->compileContainer(
+            $containerA,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'service' => 'doctrine.dbal.eventstore_connection',
+                    ],
+                    'subscription' => [
+                        'store' => [
+                            'type' => 'static_in_memory'
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->compileContainer(
+            $containerB,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => [
+                        'service' => 'doctrine.dbal.eventstore_connection',
+                    ],
+                    'subscription' => [
+                        'store' => [
+                            'type' => 'static_in_memory'
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        self::assertSame(
+            $containerA->get(SubscriptionStore::class),
+            $containerB->get(SubscriptionStore::class)
+        );
+    }
+
     public function testCatchUpSubscriptionEngine(): void
     {
         $container = new ContainerBuilder();
@@ -1052,5 +1095,4 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
 
         $container->compile();
     }
-
 }


### PR DESCRIPTION
The new option `static_in_memory` makes it possible to run the event store with [doctrine test bundle](https://github.com/dmaicher/doctrine-test-bundle)