### PR TITLE
Fix saving buffered messages in `StoreMigrateCommand`

### DIFF
--- a/src/Command/StoreMigrateCommand.php
+++ b/src/Command/StoreMigrateCommand.php
@@ -75,7 +75,7 @@ final class StoreMigrateCommand extends Command
             $style->progressAdvance($buffer);
         }
 
-        if (count($bufferedMessages) >= $buffer) {
+        if (count($bufferedMessages) !== 0) {
             $this->newStore->save(...$bufferedMessages);
             $style->progressAdvance(count($bufferedMessages));
         }


### PR DESCRIPTION
If the messages were less then the buffer, no messages were saved. Instead of checking against the buffer we only need to check if there is atleast one message.