### PR TITLE
Exclude Aggregates and Events to be registered as services

### DIFF
--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -1124,18 +1124,18 @@ final class PatchlevelEventSourcingExtension extends Extension
             static function (ChildDefinition $definition): void {
                 $definition->setAbstract(true)->addTag(
                     'container.excluded',
-                    ['source' => sprintf('with #[%s] attribute', Aggregate::class)]
+                    ['source' => sprintf('with #[%s] attribute', Aggregate::class)],
                 );
-            }
+            },
         );
         $container->registerAttributeForAutoconfiguration(
             Event::class,
             static function (ChildDefinition $definition): void {
                 $definition->setAbstract(true)->addTag(
                     'container.excluded',
-                    ['source' => sprintf('with #[%s] attribute', Event::class)]
+                    ['source' => sprintf('with #[%s] attribute', Event::class)],
                 );
-            }
+            },
         );
     }
 }

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -16,6 +16,8 @@ use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
 use Doctrine\Migrations\Tools\Console\Command\MigrateCommand;
 use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
 use Doctrine\ORM\Tools\ToolEvents;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Event;
 use Patchlevel\EventSourcing\Attribute\Processor;
 use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
@@ -149,6 +151,8 @@ final class PatchlevelEventSourcingExtension extends Extension
     /** @param array<array-key, mixed> $configs */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $this->removeNonServices($container);
+
         $configuration = new Configuration();
 
         /** @var Config $config */
@@ -1111,5 +1115,27 @@ final class PatchlevelEventSourcingExtension extends Extension
     {
         $container->register(AggregateRootIdValueResolver::class)
             ->addTag('controller.argument_value_resolver', ['priority' => 200]);
+    }
+
+    private function removeNonServices(ContainerBuilder $container): void
+    {
+        $container->registerAttributeForAutoconfiguration(
+            Aggregate::class,
+            static function (ChildDefinition $definition): void {
+                $definition->setAbstract(true)->addTag(
+                    'container.excluded',
+                    ['source' => sprintf('with #[%s] attribute', Aggregate::class)]
+                );
+            }
+        );
+        $container->registerAttributeForAutoconfiguration(
+            Event::class,
+            static function (ChildDefinition $definition): void {
+                $definition->setAbstract(true)->addTag(
+                    'container.excluded',
+                    ['source' => sprintf('with #[%s] attribute', Event::class)]
+                );
+            }
+        );
     }
 }

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -10,6 +10,8 @@ use Doctrine\Migrations\Tools\Console\Command\MigrateCommand;
 use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
 use InvalidArgumentException;
 use Patchlevel\EventSourcing\Aggregate\CustomId;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Event;
 use Patchlevel\EventSourcing\Clock\FrozenClock;
 use Patchlevel\EventSourcing\Clock\SystemClock;
 use Patchlevel\EventSourcing\CommandBus\CommandBus;
@@ -102,6 +104,7 @@ use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -148,8 +151,16 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertInstanceOf(EventRegistry::class, $container->get(EventRegistry::class));
         self::assertInstanceOf(SystemClock::class, $container->get('event_sourcing.clock'));
         self::assertInstanceOf(DefaultSubscriptionEngine::class, $container->get(SubscriptionEngine::class));
-
         self::assertFalse($container->has(EventBus::class));
+
+        $attributes = $container->getAutoconfiguredAttributes();
+        foreach ([Aggregate::class, Event::class] as $class) {
+            $definition = new ChildDefinition('');
+            $attributes[$class]($definition);
+
+            $this->assertSame([['source' => sprintf('with #[%s] attribute', $class)]], $definition->getTag('container.excluded'));
+            $this->assertTrue($definition->isAbstract());
+        }
     }
 
     public function testConnectionService(): void


### PR DESCRIPTION
Aggregates are already not registered as services before this patch, but it wont hurt to have this config explicit.