### PR TITLE
Add factories for classes with value objects as dependencies so that the symfony container can be dumped

### DIFF
--- a/src/Clock/FrozenClockFactory.php
+++ b/src/Clock/FrozenClockFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\Clock;
+
+use DateTimeImmutable;
+use Patchlevel\EventSourcing\Clock\FrozenClock;
+
+/** @internal */
+final class FrozenClockFactory
+{
+    public static function create(string $dateTimeString): FrozenClock
+    {
+        return new FrozenClock(new DateTimeImmutable($dateTimeString));
+    }
+}

--- a/src/DependencyInjection/PatchlevelEventSourcingExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingExtension.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcingBundle\DependencyInjection;
 
-use DateInterval;
-use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
 use Doctrine\Migrations\Configuration\Migration\ConfigurationArray;
@@ -117,6 +115,7 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorR
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberHelper;
 use Patchlevel\EventSourcingBundle\Attribute\AsListener;
+use Patchlevel\EventSourcingBundle\Clock\FrozenClockFactory;
 use Patchlevel\EventSourcingBundle\Command\StoreMigrateCommand;
 use Patchlevel\EventSourcingBundle\CommandBus\SymfonyCommandBus;
 use Patchlevel\EventSourcingBundle\DataCollector\EventSourcingCollector;
@@ -126,6 +125,7 @@ use Patchlevel\EventSourcingBundle\EventBus\SymfonyEventBus;
 use Patchlevel\EventSourcingBundle\QueryBus\SymfonyQueryBus;
 use Patchlevel\EventSourcingBundle\RequestListener\AutoSetupListener;
 use Patchlevel\EventSourcingBundle\RequestListener\SubscriptionRebuildAfterFileChangeListener;
+use Patchlevel\EventSourcingBundle\Subscription\Engine\GapResolverMessageLoaderFactory;
 use Patchlevel\EventSourcingBundle\Subscription\ResetServicesListener;
 use Patchlevel\EventSourcingBundle\Subscription\StaticInMemorySubscriptionStoreFactory;
 use Patchlevel\EventSourcingBundle\ValueResolver\AggregateRootIdValueResolver;
@@ -354,11 +354,12 @@ final class PatchlevelEventSourcingExtension extends Extension
         }
 
         $container->register(GapResolverStoreMessageLoader::class)
+            ->setFactory([GapResolverMessageLoaderFactory::class, 'create'])
             ->setArguments([
                 new Reference(Store::class),
                 new Reference('event_sourcing.clock'),
                 $config['subscription']['gap_detection']['retries_in_ms'],
-                new DateInterval($config['subscription']['gap_detection']['detection_window']),
+                $config['subscription']['gap_detection']['detection_window'],
             ]);
 
         $container->setAlias(MessageLoader::class, GapResolverStoreMessageLoader::class);
@@ -1068,7 +1069,8 @@ final class PatchlevelEventSourcingExtension extends Extension
     {
         if ($config['clock']['freeze'] !== null) {
             $container->register(FrozenClock::class)
-                ->setArguments([new DateTimeImmutable($config['clock']['freeze'])]);
+                ->setFactory([FrozenClockFactory::class, 'create'])
+                ->setArguments([$config['clock']['freeze']]);
 
             $container->setAlias('event_sourcing.clock', FrozenClock::class);
 

--- a/src/Subscription/Engine/GapResolverMessageLoaderFactory.php
+++ b/src/Subscription/Engine/GapResolverMessageLoaderFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\Subscription\Engine;
+
+use DateInterval;
+use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Subscription\Engine\GapResolverStoreMessageLoader;
+use Psr\Clock\ClockInterface;
+
+/** @internal */
+final class GapResolverMessageLoaderFactory
+{
+    /** @param list<int> $retriesInMs in milliseconds */
+    public static function create(
+        Store $store,
+        ClockInterface $clock,
+        array $retriesInMs,
+        string|null $detectionWindow,
+    ): GapResolverStoreMessageLoader {
+        return new GapResolverStoreMessageLoader(
+            $store,
+            $clock,
+            $retriesInMs,
+            $detectionWindow !== null ? new DateInterval($detectionWindow) : null,
+        );
+    }
+}

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -115,6 +115,7 @@ use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -1585,5 +1586,7 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         $compilerPassConfig->addPass(new TestCaseAllPublicCompilerPass());
 
         $container->compile();
+
+        (new XmlDumper($container))->dump();
     }
 }


### PR DESCRIPTION
Update `compileContainer` to dump also the container to catch these things next time.