### PR TITLE
docs: add missing type for event_bus config

### DIFF
--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -570,6 +570,7 @@ We can then use this messenger or event bus in event sourcing:
 ```yaml
 patchlevel_event_sourcing:
     event_bus:
+        type: symfony
         service: event.bus
 ```
 Since the event bus was replaced, event sourcing own attributes no longer work.


### PR DESCRIPTION
Hi!

It seams there is a missing type declaration in your docs. You can see it [here](https://github.com/patchlevel/event-sourcing-bundle/blob/3.15.x/src/DependencyInjection/PatchlevelEventSourcingExtension.php#L321).

I was not sure if this branch is the correct one. Feel free to rebase the branch to the correct branch or let me know :)

