### PR TITLE
fix: exclude event dispatcher from worker services reset

### DIFF
--- a/src/DependencyInjection/WorkerResetCompilerPass.php
+++ b/src/DependencyInjection/WorkerResetCompilerPass.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\DependencyInjection;
+
+use Patchlevel\EventSourcingBundle\Subscription\ResetServicesListener;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+
+/**
+ * Builds a worker-specific ServicesResetter that excludes the event dispatcher.
+ *
+ * In debug mode, Symfony decorates the event dispatcher with TraceableEventDispatcher
+ * and tags it with kernel.reset. When the ResetServicesListener fires during
+ * WorkerRunningEvent dispatch, the global services_resetter calls reset() on the
+ * TraceableEventDispatcher — clearing its internal state (dispatchDepth) while the
+ * event is still being dispatched. This causes an "Undefined array key" warning
+ * in postProcess() (symfony/event-dispatcher >= 8.0.8).
+ *
+ * This pass creates a separate ServicesResetter for the worker that excludes the
+ * debug.event_dispatcher, so the global services_resetter remains unchanged for
+ * HTTP request resets.
+ */
+final class WorkerResetCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(ResetServicesListener::class)) {
+            return;
+        }
+
+        if (!$container->hasDefinition('debug.event_dispatcher')) {
+            return;
+        }
+
+        $services = [];
+        /** @var array<string, list<string>> $methods */
+        $methods = [];
+
+        foreach ($container->findTaggedServiceIds('kernel.reset', true) as $id => $tags) {
+            if ($id === 'debug.event_dispatcher') {
+                continue;
+            }
+
+            $services[$id] = new Reference($id, ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE);
+
+            foreach ($tags as $attributes) {
+                /** @var array{method?: string, on_invalid?: string} $attributes */
+                if (!isset($attributes['method'])) {
+                    continue;
+                }
+
+                $methods[$id] ??= [];
+
+                $method = $attributes['method'];
+
+                if (($attributes['on_invalid'] ?? null) === 'ignore') {
+                    $method = '?' . $method;
+                }
+
+                $methods[$id][] = $method;
+            }
+        }
+
+        if ($services === []) {
+            return;
+        }
+
+        $container->register('patchlevel.worker.services_resetter', ServicesResetter::class)
+            ->setArguments([
+                new IteratorArgument($services),
+                $methods,
+            ]);
+
+        $container->getDefinition(ResetServicesListener::class)
+            ->setArgument(0, new Reference('patchlevel.worker.services_resetter'));
+    }
+}

--- a/src/PatchlevelEventSourcingBundle.php
+++ b/src/PatchlevelEventSourcingBundle.php
@@ -12,6 +12,7 @@ use Patchlevel\EventSourcingBundle\DependencyInjection\QueryHandlerCompilerPass;
 use Patchlevel\EventSourcingBundle\DependencyInjection\RepositoryCompilerPass;
 use Patchlevel\EventSourcingBundle\DependencyInjection\SubscriberGuardCompilePass;
 use Patchlevel\EventSourcingBundle\DependencyInjection\TranslatorCompilerPass;
+use Patchlevel\EventSourcingBundle\DependencyInjection\WorkerResetCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,5 +28,6 @@ final class PatchlevelEventSourcingBundle extends Bundle
         $container->addCompilerPass(new TranslatorCompilerPass());
         $container->addCompilerPass(new DoctrineCleanupCompilerPass());
         $container->addCompilerPass(new HydratorCompilerPass());
+        $container->addCompilerPass(new WorkerResetCompilerPass());
     }
 }

--- a/tests/Unit/DependencyInjection/WorkerResetCompilerPassTest.php
+++ b/tests/Unit/DependencyInjection/WorkerResetCompilerPassTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingBundle\Tests\Unit\DependencyInjection;
+
+use Patchlevel\EventSourcingBundle\DependencyInjection\WorkerResetCompilerPass;
+use Patchlevel\EventSourcingBundle\Subscription\ResetServicesListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+
+final class WorkerResetCompilerPassTest extends TestCase
+{
+    public function testCreatesFilteredResetterWhenDebugDispatcherExists(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(ResetServicesListener::class)
+            ->setArguments([new Reference('services_resetter')]);
+
+        $container->register('debug.event_dispatcher')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->register('some.other.service')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        self::assertTrue($container->hasDefinition('patchlevel.worker.services_resetter'));
+
+        $definition = $container->getDefinition('patchlevel.worker.services_resetter');
+        self::assertSame(ServicesResetter::class, $definition->getClass());
+
+        /** @var array<string, list<string>> $methods */
+        $methods = $definition->getArgument(1);
+        self::assertArrayNotHasKey('debug.event_dispatcher', $methods);
+        self::assertArrayHasKey('some.other.service', $methods);
+        self::assertSame(['reset'], $methods['some.other.service']);
+
+        $listenerDef = $container->getDefinition(ResetServicesListener::class);
+        self::assertEquals(
+            new Reference('patchlevel.worker.services_resetter'),
+            $listenerDef->getArgument(0),
+        );
+    }
+
+    public function testSkipsWhenNoDebugDispatcher(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(ResetServicesListener::class)
+            ->setArguments([new Reference('services_resetter')]);
+
+        $container->register('some.other.service')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        self::assertFalse($container->hasDefinition('patchlevel.worker.services_resetter'));
+
+        $listenerDef = $container->getDefinition(ResetServicesListener::class);
+        self::assertEquals(
+            new Reference('services_resetter'),
+            $listenerDef->getArgument(0),
+        );
+    }
+
+    public function testSkipsWhenNoResetServicesListener(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('debug.event_dispatcher')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->register('some.other.service')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        // The pass must not create the worker resetter when the listener is absent.
+        self::assertFalse($container->hasDefinition('patchlevel.worker.services_resetter'));
+    }
+
+    public function testSkipsWhenNoResettableServicesRemain(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(ResetServicesListener::class)
+            ->setArguments([new Reference('services_resetter')]);
+
+        $container->register('debug.event_dispatcher')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        self::assertFalse($container->hasDefinition('patchlevel.worker.services_resetter'));
+    }
+
+    public function testHandlesOnInvalidIgnoreAttribute(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(ResetServicesListener::class)
+            ->setArguments([new Reference('services_resetter')]);
+
+        $container->register('debug.event_dispatcher')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->register('some.service')
+            ->addTag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        self::assertTrue($container->hasDefinition('patchlevel.worker.services_resetter'));
+
+        /** @var array<string, list<string>> $methods */
+        $methods = $container->getDefinition('patchlevel.worker.services_resetter')->getArgument(1);
+        self::assertSame(['?reset'], $methods['some.service']);
+    }
+
+    public function testSkipsTagsWithoutMethodAttribute(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(ResetServicesListener::class)
+            ->setArguments([new Reference('services_resetter')]);
+
+        $container->register('debug.event_dispatcher')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->register('some.service')
+            ->addTag('kernel.reset', [])
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        /** @var array<string, list<string>> $methods */
+        $methods = $container->getDefinition('patchlevel.worker.services_resetter')->getArgument(1);
+        self::assertSame(['reset'], $methods['some.service']);
+    }
+
+    public function testPreservesMultipleResetMethodsOnSameService(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(ResetServicesListener::class)
+            ->setArguments([new Reference('services_resetter')]);
+
+        $container->register('debug.event_dispatcher')
+            ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->register('some.service')
+            ->addTag('kernel.reset', ['method' => 'resetA'])
+            ->addTag('kernel.reset', ['method' => 'resetB']);
+
+        $pass = new WorkerResetCompilerPass();
+        $pass->process($container);
+
+        /** @var array<string, list<string>> $methods */
+        $methods = $container->getDefinition('patchlevel.worker.services_resetter')->getArgument(1);
+        self::assertSame(['resetA', 'resetB'], $methods['some.service']);
+    }
+}

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -1543,6 +1543,36 @@ final class PatchlevelEventSourcingBundleTest extends TestCase
         self::assertInstanceOf(ResetServicesListener::class, $container->get(ResetServicesListener::class));
     }
 
+    public function testWorkerResetExcludesDebugDispatcher(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('debug.event_dispatcher', \stdClass::class)
+            ->addTag('kernel.reset', ['method' => 'reset'])
+            ->setPublic(true);
+
+        $container->register('some.resettable.service', \stdClass::class)
+            ->addTag('kernel.reset', ['method' => 'reset'])
+            ->setPublic(true);
+
+        $this->compileContainer(
+            $container,
+            [
+                'patchlevel_event_sourcing' => [
+                    'connection' => ['service' => 'doctrine.dbal.eventstore_connection'],
+                ],
+            ],
+        );
+
+        self::assertTrue($container->has('patchlevel.worker.services_resetter'));
+
+        $listenerDef = $container->getDefinition(ResetServicesListener::class);
+        self::assertEquals(
+            new Reference('patchlevel.worker.services_resetter'),
+            $listenerDef->getArgument(0),
+        );
+    }
+
     public function testNamedRepository(): void
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
## Problem

`ResetServicesListener::onWorkerRunningEvent()` calls `$servicesResetter->reset()`, which resets **all** services tagged with `kernel.reset` — including `debug.event_dispatcher` (`TraceableEventDispatcher`) that is currently dispatching the `WorkerRunningEvent`.

In `symfony/event-dispatcher` v8.0.8, `TraceableEventDispatcher` added `dispatchDepth` tracking. The `reset()` call clears `$this->dispatchDepth` mid-dispatch, causing an "Undefined array key" warning in `postProcess()`:

```
Warning: Undefined array key "Patchlevel\Worker\Event\WorkerRunningEvent"
```

Depending on error handling configuration, this warning is promoted to `ErrorException`, breaking `subscription:boot` and `subscription:run` in debug mode.

## Fix

Add `WorkerResetCompilerPass` that, when `debug.event_dispatcher` is present, builds a **worker-specific** `ServicesResetter` excluding the debug event dispatcher. The `ResetServicesListener` is then rewired to use this filtered resetter.

The global `services_resetter` remains unchanged — HTTP request resets still include the event dispatcher as before.

## Changes

- `src/DependencyInjection/WorkerResetCompilerPass.php` — new compiler pass
- `src/PatchlevelEventSourcingBundle.php` — register the pass
- `tests/Unit/DependencyInjection/WorkerResetCompilerPassTest.php` — unit tests

Fixes #309