### PR TITLE
fix: use ResetInterface to support Symfony 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "symfony/event-dispatcher": "^6.4.1 || ^7.0.1 || ^8.0.0",
     "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0",
     "symfony/http-kernel": "^6.4.1 || ^7.0.1 || ^8.0.0",
-    "symfony/messenger": "^6.4.0 || ^7.0.0 || ^8.0.0"
+    "symfony/messenger": "^6.4.0 || ^7.0.0 || ^8.0.0",
+    "symfony/service-contracts": "^2.5 || ^3.0"
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",

--- a/src/Subscription/ResetServicesListener.php
+++ b/src/Subscription/ResetServicesListener.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcingBundle\Subscription;
 
 use Patchlevel\Worker\Event\WorkerRunningEvent;
-use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Contracts\Service\ResetInterface;
 
 final readonly class ResetServicesListener
 {
-    public function __construct(private ServicesResetter $servicesResetter)
+    public function __construct(private ResetInterface $servicesResetter)
     {
     }
 


### PR DESCRIPTION
## Problem

Symfony 8.1 moved `ServicesResetter` from `HttpKernel\DependencyInjection` to `DependencyInjection` ([symfony/symfony commit](https://github.com/symfony/symfony/commit/0e6a6ccb)). The container now injects `Symfony\Component\DependencyInjection\ServicesResetter`. Since `HttpKernel\ServicesResetter` **extends** the DI version (not the other way around), passing the DI version where the HttpKernel subclass is expected causes a `TypeError` at container boot.

## Fix

Change the type hint from `Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter` to `Symfony\Contracts\Service\ResetInterface`:

- Works across Symfony 6.4, 7.x, and 8.x
- `ServicesResetter` has always implemented `ResetInterface`
- Same approach used by Symfony's own `Messenger\EventListener\ResetServicesListener` in 8.1
- Adds `symfony/service-contracts` as an explicit dependency (was already transitive via `http-kernel`)

The `'services_resetter'` service ID in `PatchlevelEventSourcingExtension` is unchanged — it remains the stable service ID across all versions.

Fixes #316